### PR TITLE
ci: migrate cargo-nextest install to taiki-e/install-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,10 +103,9 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - name: Install cargo-nextest
-        uses: baptiste0928/cargo-install@v3
+        uses: taiki-e/install-action@v2
         with:
-          crate: cargo-nextest
-          locked: true
+          tool: cargo-nextest
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2
       - name: Basic build


### PR DESCRIPTION
## Summary
- Replace `baptiste0928/cargo-install@v3` with `taiki-e/install-action@v2` for installing `cargo-nextest` in the test job
- Aligns with the rest of the workflow which already uses `taiki-e/install-action` for `just` and `cargo-udeps`

## Test plan
- [ ] CI passes on all three platforms (ubuntu, macos, windows)